### PR TITLE
Populate README with user input

### DIFF
--- a/{{cookiecutter.role_name}}/README.md
+++ b/{{cookiecutter.role_name}}/README.md
@@ -30,7 +30,7 @@ Including an example of how to use your role (for instance, with variables passe
 License
 -------
 
-BSD
+{{ cookiecutter.license }}
 
 Author Information
 ------------------

--- a/{{cookiecutter.role_name}}/README.md
+++ b/{{cookiecutter.role_name}}/README.md
@@ -1,7 +1,7 @@
 Role Name
 =========
 
-A brief description of the role goes here.
+{{ cookiecutter.description }}
 
 Requirements
 ------------


### PR DESCRIPTION
I noticed that the README license is fixed and does not use the license information provided by the user. Also, the brief description in the README should also be templated from the user input.